### PR TITLE
Make version default as 26.3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,7 @@ author: 'Steve Purcell'
 inputs:
   version:
     description: 'The version of Emacs to install, e.g. "24.3", or "snapshot" for a recent development version.'
+    default: '26.3'
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
Hi!
I fill default field, so if users need just Emacs, users omit version specification.