### PR TITLE
Fail faster on missing deps

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,12 +4,15 @@
 
 set -euo pipefail
 
-deps="'sudo', 'curl', 'xz'"
-type -p sudo || (1>/dev/stderr echo "Please install $deps"; exit 1)
-type -p curl || (1>/dev/stderr echo "Please install $deps"; exit 1)
-type -p xz || (1>/dev/stderr echo "Please install $deps"; exit 1)
-
 if ! type -p nix &>/dev/null ; then
+    missing_deps=""
+    for dep in sudo curl xz; do
+      type -p "$dep" || exec missing_deps="$dep $missing_deps"
+    done
+    if [ -n "$missing_deps" ]; then
+      echo "The nix installer will require some programs that are not installed: $missing_deps" >&2
+      exit 1
+    fi
     env INPUT_EXTRA_NIX_CONFIG= \
         INPUT_INSTALL_OPTIONS= \
         INPUT_INSTALL_URL= \

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,11 @@
 
 set -euo pipefail
 
+deps="'sudo', 'curl', 'xz'"
+type -p sudo || (1>/dev/stderr echo "Please install $deps"; exit 1)
+type -p curl || (1>/dev/stderr echo "Please install $deps"; exit 1)
+type -p xz || (1>/dev/stderr echo "Please install $deps"; exit 1)
+
 if ! type -p nix &>/dev/null ; then
     env INPUT_EXTRA_NIX_CONFIG= \
         INPUT_INSTALL_OPTIONS= \


### PR DESCRIPTION
When running locally with [`act`](https://github.com/nektos/act) this fails depending on the image used because it relies on some, binaries being available by default:
* `curl` probably won't be as it's common to have `wget` or neither
* `xz` might not be present in case "complete" `tar` installation is provided
* and, if working with Alpine, `sudo` either won't be because `doas` [is recommended](https://wiki.alpinelinux.org/wiki/Setting_up_a_new_user#sudo) there or the runner image is custom-built without super-user capabilities in mind

This notifies the user faster because normally it'll fail on `sudo` first, then after the first iteration it'll fail on `curl` and after the second on missing `xz` for decompression.