### PR TITLE
Update the branch in the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See the [actions tab](https://github.com/purcell/setup-emacs/actions) for runs o
 ## Usage:
 
 ```yaml
-uses: purcell/setup-emacs@master
+uses: purcell/setup-emacs@main
 with:
   version: 24.5
   ```


### PR DESCRIPTION
It looks like the `master` branch has been removed, presumably in favour of `main`. The README still says to use from `master`. This PR changes that.